### PR TITLE
Fix cx:if directive

### DIFF
--- a/packages/core/src/directives/if.ts
+++ b/packages/core/src/directives/if.ts
@@ -11,11 +11,28 @@ export const ifDirective: Directive = {
   apply(el, attr, expr) {
     el.removeAttribute('cx:if');
 
+    const placeholder = document.createComment('');
+    let inserted = true;
+
     const toggle = (visible: boolean) => {
-      el.style.display = visible ? '' : 'none';
+      if (visible) {
+        if (!inserted) {
+          placeholder.replaceWith(el);
+          inserted = true;
+        }
+      } else if (inserted) {
+        el.replaceWith(placeholder);
+        inserted = false;
+      }
     };
 
+    const initial = isFunction(expr) ? expr() : Boolean(expr);
+    if (!initial) {
+      el.replaceWith(placeholder);
+      inserted = false;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    isFunction(expr) ? effect(() => toggle(expr())) : toggle(Boolean(expr));
+    isFunction(expr) ? effect(() => toggle(expr())) : undefined;
   },
 };

--- a/packages/core/test/directives/if.test.ts
+++ b/packages/core/test/directives/if.test.ts
@@ -1,6 +1,6 @@
 import { html } from '@crux/core';
 import { createSignal } from '@crux/reactivity';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 async function flushEffects() {
   return new Promise((resolve) => {
@@ -9,6 +9,9 @@ async function flushEffects() {
 }
 
 describe('ifDirective', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
   it('cx:if toggles visibility', async () => {
     const [show, setShow] = createSignal(true);
     const frag = html` <div cx:if=${() => show()}>Visible</div>`;
@@ -20,5 +23,37 @@ describe('ifDirective', () => {
     await flushEffects();
 
     expect(document.body.textContent).not.toContain('Visible');
+  });
+
+  it('cx:if does not block reactive updates when hidden', async () => {
+    const [count, setCount] = createSignal(0);
+    const frag = html`
+      <div id="toggle" cx:if=${() => count() < 10}>Less than ten</div>
+      <span id="display">${() => count()}</span>
+    `;
+    document.body.appendChild(frag);
+
+    const display = document.getElementById('display') as HTMLElement;
+
+    expect(display.textContent).toBe('0');
+    expect(document.getElementById('toggle')).not.toBeNull();
+
+    setCount(10);
+    await flushEffects();
+
+    expect(display.textContent).toBe('10');
+    expect(document.getElementById('toggle')).toBeNull();
+
+    setCount(11);
+    await flushEffects();
+
+    expect(display.textContent).toBe('11');
+    expect(document.getElementById('toggle')).toBeNull();
+
+    setCount(2);
+    await flushEffects();
+
+    expect(display.textContent).toBe('2');
+    expect(document.getElementById('toggle')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- improve `cx:if` directive so it removes and re-inserts nodes when the expression is false/true
- add test ensuring elements hidden with `cx:if` do not block signal updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68420ecb3a08832fbf59b7e4f2f45f1f