### PR TITLE
Refactor and cleanup

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -58,7 +58,7 @@ export function useContext<T>(context: Context<T>): Signal<T> | undefined {
   return context.defaultValue as Signal<T>;
 }
 
-// 🧪 For testing only
+/** Internal helper to reset the context stack for tests. */
 export function _resetContextStack(): void {
   contextStack.length = 0;
   currentContextMap = new Map();

--- a/packages/context/test/context.test.ts
+++ b/packages/context/test/context.test.ts
@@ -1,4 +1,3 @@
-// context.test.ts
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -3,8 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": [
-    "src",
-    "test"
-  ]
+  "include": ["src", "test"]
 }

--- a/packages/core/src/createCruxApp.ts
+++ b/packages/core/src/createCruxApp.ts
@@ -1,6 +1,8 @@
 interface CreateCruxAppOptions {
-  root: string; // custom element tag name, e.g., 'my-app'
-  selector: string; // CSS selector to mount on
+  /** Custom element tag name, e.g., 'my-app' */
+  root: string;
+  /** CSS selector to mount on */
+  selector: string;
 }
 
 export function createCruxApp({ root, selector }: CreateCruxAppOptions) {

--- a/packages/core/src/directives/event.ts
+++ b/packages/core/src/directives/event.ts
@@ -1,12 +1,10 @@
 import { Directive } from './types';
 
 export const eventDirective: Directive = {
-  match(attr: any) {
-    console.log('hello');
+  match(attr: Attr) {
     return attr.name.startsWith('cx-on:');
   },
-  apply(el: any, attr: any, expr: any) {
-    console.log('goodbye');
+  apply(el: Element, attr: Attr, expr: EventListenerOrEventListenerObject) {
     const event = attr.name.slice(6);
     el.addEventListener(event, expr);
   },

--- a/packages/core/src/directives/reactiveAttr.ts
+++ b/packages/core/src/directives/reactiveAttr.ts
@@ -7,16 +7,14 @@ import { Directive } from './types';
 const blocked = ['srcdoc', 'style', 'href', 'src', 'xlink:href'];
 
 export const reactiveAttrDirective: Directive = {
-  match(attr: any) {
-    console.log('reactiveMatch');
+  match(attr: Attr) {
     const name = attr.name;
     if (name === 'cx:if') return false; // exclude explicitly
     return name.startsWith('cx:') && !blocked.includes(name.slice(3));
   },
-  apply(el: any, attr: any, expr: any) {
-    console.log('reactive apply');
+  apply(el: Element, attr: Attr, expr: unknown) {
     const target = attr.name.slice(3);
-    const setter = (v: any) => el.setAttribute(target, String(v));
+    const setter = (v: unknown) => el.setAttribute(target, String(v));
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     isFunction(expr) ? effect(() => setter(unwrap(expr))) : setter(expr);
   },

--- a/packages/core/src/html.ts
+++ b/packages/core/src/html.ts
@@ -78,12 +78,7 @@ export function html<T extends unknown[]>(
       const idx = +m[1];
       const expr = vals[idx];
       el.removeAttribute(attr.name);
-      console.log('allDirectives', allDirectives);
-
       for (const directive of allDirectives) {
-        console.log('directive', directive);
-        console.log('attr', attr);
-        console.log('directive.match(attr)', directive.match(attr));
         if (directive.match(attr)) {
           directive.apply(el, attr, expr);
           break;

--- a/packages/core/test/component.test.ts
+++ b/packages/core/test/component.test.ts
@@ -1,4 +1,3 @@
-// component.test.ts
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent } from '@crux/core';
 

--- a/packages/core/test/createCruxApp.test.ts
+++ b/packages/core/test/createCruxApp.test.ts
@@ -1,4 +1,3 @@
-// packages/core/test/createCruxApp.test.ts
 import { describe, expect, vi } from 'vitest';
 import { createCruxApp } from '@crux/core';
 

--- a/packages/core/test/html.test.ts
+++ b/packages/core/test/html.test.ts
@@ -1,4 +1,3 @@
-// packages/core/test/html.test.ts
 import { describe, expect, it, vi } from 'vitest';
 import { createSignal } from '@crux/reactivity';
 

--- a/packages/reactivity/test/effect.test.ts
+++ b/packages/reactivity/test/effect.test.ts
@@ -1,4 +1,3 @@
-// effect.test.ts
 import { describe, expect, it, vi } from 'vitest';
 
 import { effect, onCleanup } from '../src/effect';
@@ -84,7 +83,7 @@ describe('effect (integration with signal)', () => {
   it('handles case where cleanupMap.get returns undefined', () => {
     // This branch triggers the `?? []` fallback
     // We use a stub signal that doesn't actually track
-    const [_, set] = createSignal(0);
+    createSignal(0);
     expect(() => {
       effect(() => {
         // No actual dependencies, so cleanupMap.get will be undefined

--- a/packages/reactivity/test/scheduler.test.ts
+++ b/packages/reactivity/test/scheduler.test.ts
@@ -1,4 +1,3 @@
-// scheduler.test.ts
 import { describe, expect, it, vi } from 'vitest';
 
 import { flush, queueJob } from '../src/scheduler';


### PR DESCRIPTION
## Summary
- drop leftover debug logs
- remove empty unused file
- standardize test headers
- tidy comments

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684222fcba7c832f97db351e0d1184f2