### PR TITLE
Add ramda dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   ],
   "author": "synth-rabbit <josh.dean.edwards@gmail.com>",
   "license": "MIT",
+  "dependencies": {
+    "ramda": "^0.30.0"
+  },
   "packageManager": "pnpm@8.14.2+sha1.1670a65b60df5f95e9f0cb7de46e605d9bd74fda",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",


### PR DESCRIPTION
## Summary
- add `ramda` as a runtime dependency

## Testing
- `pnpm exec vitest run`
- `pnpm install` *(fails: GET https://registry.npmjs.org/ramda: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_6842475724b0832f8a6e606c71bf699f