### PR TITLE
Apply functional style with Ramda

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -1,4 +1,5 @@
 import { createSignal, Signal } from '@crux/reactivity';
+import { find, reverse } from 'ramda';
 
 export interface Context<T> {
   id: symbol;
@@ -48,14 +49,11 @@ export function provide<T>(context: Context<T>, defaultValue?: T) {
  * Retrieves the signal for a given context.
  */
 export function useContext<T>(context: Context<T>): Signal<T> | undefined {
-  for (let i = contextStack.length - 1; i >= 0; i--) {
-    const map = contextStack[i];
-    if (map.has(context.id)) {
-      return map.get(context.id) as Signal<T>;
-    }
-  }
-
-  return context.defaultValue as Signal<T>;
+  const map = find<ContextMap>(
+    (m) => m.has(context.id),
+    reverse(contextStack)
+  );
+  return map ? (map.get(context.id) as Signal<T>) : (context.defaultValue as Signal<T>);
 }
 
 /** Internal helper to reset the context stack for tests. */

--- a/packages/core/src/createCruxApp.ts
+++ b/packages/core/src/createCruxApp.ts
@@ -5,9 +5,11 @@ interface CreateCruxAppOptions {
   selector: string;
 }
 
+import { isNil } from 'ramda';
+
 export function createCruxApp({ root, selector }: CreateCruxAppOptions) {
   const mountPoint = document.querySelector(selector);
-  if (!mountPoint) {
+  if (isNil(mountPoint)) {
     console.error(`[crux] Mount point '${selector}' not found.`);
     return;
   }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,4 +1,5 @@
 import { effect } from '@crux/reactivity';
+import { map } from 'ramda';
 
 export const cxText = <T>(sig: () => T) => {
   const node = document.createTextNode(String(sig()));
@@ -11,7 +12,7 @@ export const cxText = <T>(sig: () => T) => {
 export const cxList =
   <T>(getList: () => T[], mapFn: (item: T) => Node) =>
   () =>
-    getList().map(mapFn);
+    map(mapFn, getList());
 
 export const cxClass =
   (condition: () => boolean, trueClass: string, falseClass = '') =>

--- a/packages/reactivity/src/scheduler.ts
+++ b/packages/reactivity/src/scheduler.ts
@@ -1,5 +1,6 @@
 // scheduler.ts
 import type { ReactiveEffect } from './types';
+import { includes, forEach } from 'ramda';
 
 const queue: ReactiveEffect[] = [];
 let flushing = false;
@@ -9,7 +10,7 @@ let flushing = false;
  * Ensures effects added during a flush cycle are deferred to the next microtask.
  */
 export function queueJob(job: ReactiveEffect): void {
-  if (!queue.includes(job)) {
+  if (!includes(job, queue)) {
     queue.push(job);
     if (!flushing) {
       queueMicrotask(flush);
@@ -27,12 +28,12 @@ export function flush(): void {
     const pending = queue.slice();
     queue.length = 0;
 
-    for (const job of pending) {
+    forEach((job: ReactiveEffect) => {
       if (!seen.has(job)) {
         seen.add(job);
         job();
       }
-    }
+    }, pending);
   }
 
   flushing = false;

--- a/packages/reactivity/src/signal.ts
+++ b/packages/reactivity/src/signal.ts
@@ -1,6 +1,7 @@
 import { queueJob } from './scheduler';
 import { currentEffect } from './effect';
 import type { ReactiveEffect, Signal } from './types';
+import { forEach } from 'ramda';
 
 export function createSignal<T>(initialValue: T): Signal<T> {
   let value = initialValue;
@@ -18,9 +19,7 @@ export function createSignal<T>(initialValue: T): Signal<T> {
 
     value = newValue;
 
-    for (const sub of subscribers) {
-      queueJob(sub);
-    }
+    forEach(queueJob, Array.from(subscribers));
   }
 
   return [read, write];


### PR DESCRIPTION
## Summary
- refactor helper utilities to use `ramda` functions
- adopt functional patterns in signal and scheduler implementations
- simplify context lookup logic using ramda helpers
- rewrite HTML rendering helpers with ramda for clarity
- clean up app creation logic

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842e07f58a4832fa0514b0ff71ab151