### PR TITLE
Add new directives to Crux core

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Crux is a small experimental frontend framework.  It is organised as a `pnpm` wo
 
 - **`@crux/reactivity`** – signal based reactivity with `createSignal`, `effect`, and `computed`.  A tiny scheduler ensures effects run asynchronously.
 - **`@crux/context`** – context utilities (`createContext`, `provide`, `useContext`) built on top of signals.
-- **`@crux/core`** – helpers for creating custom elements and rendering HTML templates.  Includes the `html` template tag and directives such as `cx-on` and `cx:if`.
+- **`@crux/core`** – helpers for creating custom elements and rendering HTML templates.  Includes the `html` template tag and directives such as `cx-on`, `cx:if`, `cx:show`, `cx:model`, `cx:style`, and `cx:for`.
 
 ## Getting started
 

--- a/packages/core/src/directives/for.ts
+++ b/packages/core/src/directives/for.ts
@@ -1,0 +1,35 @@
+import { effect } from '@crux/reactivity';
+
+import { isFunction } from '../utils';
+import { Directive } from './types';
+
+export const forDirective: Directive = {
+  match(attr) {
+    return attr.name === 'cx:for';
+  },
+  apply(el, attr, expr) {
+    el.removeAttribute('cx:for');
+    const parent = el.parentNode!;
+    const placeholder = document.createComment('');
+    const template = el.cloneNode(true) as Element;
+    parent.replaceChild(placeholder, el);
+
+    let nodes: Node[] = [];
+    const render = (list: unknown[]) => {
+      nodes.forEach((n) => n.remove());
+      nodes = [];
+      if (!Array.isArray(list)) return;
+      for (let i = 0; i < list.length; i++) {
+        const clone = template.cloneNode(true);
+        parent.insertBefore(clone, placeholder);
+        nodes.push(clone);
+      }
+    };
+
+    const initial = isFunction(expr) ? expr() : expr;
+    render(initial as unknown[]);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isFunction(expr) ? effect(() => render(expr() as unknown[])) : undefined;
+  },
+};

--- a/packages/core/src/directives/index.ts
+++ b/packages/core/src/directives/index.ts
@@ -2,5 +2,17 @@ import { Directive } from './types';
 import { eventDirective } from './event';
 import { reactiveAttrDirective } from './reactiveAttr';
 import { ifDirective } from './if';
+import { forDirective } from './for';
+import { showDirective } from './show';
+import { modelDirective } from './model';
+import { styleDirective } from './style';
 
-export const allDirectives: Directive[] = [eventDirective, reactiveAttrDirective, ifDirective];
+export const allDirectives: Directive[] = [
+  eventDirective,
+  reactiveAttrDirective,
+  ifDirective,
+  forDirective,
+  showDirective,
+  modelDirective,
+  styleDirective,
+];

--- a/packages/core/src/directives/model.ts
+++ b/packages/core/src/directives/model.ts
@@ -1,0 +1,26 @@
+import { effect } from '@crux/reactivity';
+
+import { Directive } from './types';
+
+export const modelDirective: Directive = {
+  match(attr) {
+    return attr.name === 'cx:model';
+  },
+  apply(el, attr, expr: unknown) {
+    el.removeAttribute('cx:model');
+    if (!Array.isArray(expr) || expr.length !== 2) return;
+    const [get, set] = expr as [() => any, (v: any) => void];
+    const input = el as HTMLInputElement;
+
+    const update = () => {
+      input.value = String(get());
+    };
+
+    update();
+    effect(update);
+
+    input.addEventListener('input', (e: Event) => {
+      set((e.target as HTMLInputElement).value);
+    });
+  },
+};

--- a/packages/core/src/directives/reactiveAttr.ts
+++ b/packages/core/src/directives/reactiveAttr.ts
@@ -9,7 +9,14 @@ const blocked = ['srcdoc', 'style', 'href', 'src', 'xlink:href'];
 export const reactiveAttrDirective: Directive = {
   match(attr: Attr) {
     const name = attr.name;
-    if (name === 'cx:if') return false; // exclude explicitly
+    if (
+      name === 'cx:if' ||
+      name === 'cx:for' ||
+      name === 'cx:show' ||
+      name === 'cx:model' ||
+      name.startsWith('cx:style:')
+    )
+      return false;
     return name.startsWith('cx:') && !blocked.includes(name.slice(3));
   },
   apply(el: Element, attr: Attr, expr: unknown) {

--- a/packages/core/src/directives/show.ts
+++ b/packages/core/src/directives/show.ts
@@ -1,0 +1,23 @@
+import { effect } from '@crux/reactivity';
+
+import { isFunction } from '../utils';
+import { Directive } from './types';
+
+export const showDirective: Directive = {
+  match(attr) {
+    return attr.name === 'cx:show';
+  },
+  apply(el, attr, expr) {
+    el.removeAttribute('cx:show');
+
+    const toggle = (val: unknown) => {
+      (el as HTMLElement).style.display = val ? '' : 'none';
+    };
+
+    const initial = isFunction(expr) ? expr() : expr;
+    toggle(initial);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isFunction(expr) ? effect(() => toggle(expr())) : undefined;
+  },
+};

--- a/packages/core/src/directives/style.ts
+++ b/packages/core/src/directives/style.ts
@@ -1,0 +1,19 @@
+import { effect } from '@crux/reactivity';
+
+import { isFunction, unwrap } from '../utils';
+import { Directive } from './types';
+
+export const styleDirective: Directive = {
+  match(attr) {
+    return attr.name.startsWith('cx:style:');
+  },
+  apply(el, attr, expr) {
+    const prop = attr.name.slice('cx:style:'.length);
+    el.removeAttribute(attr.name);
+    const update = (v: unknown) => {
+      (el as HTMLElement).style.setProperty(prop, String(v));
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isFunction(expr) ? effect(() => update(unwrap(expr))) : update(expr);
+  },
+};

--- a/packages/core/test/directives/for.test.ts
+++ b/packages/core/test/directives/for.test.ts
@@ -1,0 +1,30 @@
+import { html } from '@crux/core';
+import { createSignal } from '@crux/reactivity';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+async function flushEffects() {
+  return new Promise((resolve) => {
+    queueMicrotask(() => queueMicrotask(resolve));
+  });
+}
+
+describe('forDirective', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders elements for each array item', async () => {
+    const [items, setItems] = createSignal([1, 2]);
+    const frag = html` <ul>
+      <li cx:for=${() => items()}>Item</li>
+    </ul>`;
+    document.body.appendChild(frag);
+
+    expect(document.querySelectorAll('li').length).toBe(2);
+
+    setItems([1, 2, 3]);
+    await flushEffects();
+
+    expect(document.querySelectorAll('li').length).toBe(3);
+  });
+});

--- a/packages/core/test/directives/model.test.ts
+++ b/packages/core/test/directives/model.test.ts
@@ -1,0 +1,32 @@
+import { html } from '@crux/core';
+import { createSignal } from '@crux/reactivity';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+async function flushEffects() {
+  return new Promise((resolve) => {
+    queueMicrotask(() => queueMicrotask(resolve));
+  });
+}
+
+describe('modelDirective', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('binds input value to signal', async () => {
+    const signal = createSignal('a');
+    const frag = html` <input id="inp" cx:model=${signal} />`;
+    document.body.appendChild(frag);
+    const input = document.getElementById('inp') as HTMLInputElement;
+
+    expect(input.value).toBe('a');
+
+    input.value = 'b';
+    input.dispatchEvent(new Event('input'));
+    expect(signal[0]()).toBe('b');
+
+    signal[1]('c');
+    await flushEffects();
+    expect(input.value).toBe('c');
+  });
+});

--- a/packages/core/test/directives/show.test.ts
+++ b/packages/core/test/directives/show.test.ts
@@ -1,0 +1,32 @@
+import { html } from '@crux/core';
+import { createSignal } from '@crux/reactivity';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+async function flushEffects() {
+  return new Promise((resolve) => {
+    queueMicrotask(() => queueMicrotask(resolve));
+  });
+}
+
+describe('showDirective', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('toggles element visibility', async () => {
+    const [visible, setVisible] = createSignal(true);
+    const frag = html` <div id="el" cx:show=${() => visible()}>X</div>`;
+    document.body.appendChild(frag);
+    const el = document.getElementById('el') as HTMLElement;
+
+    expect(el.style.display).toBe('');
+
+    setVisible(false);
+    await flushEffects();
+    expect(el.style.display).toBe('none');
+
+    setVisible(true);
+    await flushEffects();
+    expect(el.style.display).toBe('');
+  });
+});

--- a/packages/core/test/directives/style.test.ts
+++ b/packages/core/test/directives/style.test.ts
@@ -1,0 +1,28 @@
+import { html } from '@crux/core';
+import { createSignal } from '@crux/reactivity';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+async function flushEffects() {
+  return new Promise((resolve) => {
+    queueMicrotask(() => queueMicrotask(resolve));
+  });
+}
+
+describe('styleDirective', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('updates style properties reactively', async () => {
+    const [color, setColor] = createSignal('red');
+    const frag = html` <div id="el" cx:style:color=${() => color()}></div>`;
+    document.body.appendChild(frag);
+    const el = document.getElementById('el') as HTMLElement;
+
+    expect(el.style.color).toBe('red');
+
+    setColor('blue');
+    await flushEffects();
+    expect(el.style.color).toBe('blue');
+  });
+});

--- a/playground/components/App.ts
+++ b/playground/components/App.ts
@@ -1,4 +1,10 @@
-import { cxClass, cxList, cxText, defineComponent, html } from '@crux/core';
+import {
+  cxClass,
+  cxList,
+  cxText,
+  defineComponent,
+  html,
+} from '@crux/core';
 import { provide, useContext } from '@crux/context';
 import { computed, createSignal } from '@crux/reactivity';
 import { ThemeContext } from '../context/ThemeContext';
@@ -18,6 +24,12 @@ defineComponent('my-app', () => {
   const [show, setShow] = createSignal(true);
   // List of strings for the cxList helper
   const [items, setItems] = createSignal<string[]>(['one', 'two']);
+  // For cx:show demonstration
+  const [visible, setVisible] = createSignal(true);
+  // For cx:model demonstration
+  const nameSignal = createSignal('');
+  // For cx:style demonstration
+  const [color, setColor] = createSignal('red');
 
   return html`
     <style>
@@ -65,15 +77,43 @@ defineComponent('my-app', () => {
 
     <section>
       <h2>Context & Reactive Attribute (cx:class)</h2>
-      <p cx:class=${cxClass(() => theme() === 'dark', 'dark', 'light')} cx:title=${() => `Theme is ${theme()}` }>
+      <p
+        cx:class=${cxClass(() => theme() === 'dark', 'dark', 'light')}
+        cx:title=${() => `Theme is ${theme()}`}
+      >
         Theme: ${cxText(() => theme())}
       </p>
-      <button cx-on:click=${() =>
-        setTheme(theme() === 'dark' ? 'light' : 'dark')}
-      >
+      <button cx-on:click=${() => setTheme(theme() === 'dark' ? 'light' : 'dark')}>
         Toggle Theme
       </button>
       <context-child></context-child>
+    </section>
+
+    <section>
+      <h2>Show Directive (cx:show)</h2>
+      <button cx-on:click=${() => setVisible(!visible())}>Toggle visibility</button>
+      <p cx:show=${() => visible()}>I toggle display</p>
+    </section>
+
+    <section>
+      <h2>Model Directive (cx:model)</h2>
+      <input cx:model=${nameSignal} placeholder="Type your name" />
+      <p>Name: ${cxText(() => nameSignal[0]())}</p>
+    </section>
+
+    <section>
+      <h2>Style Directive (cx:style)</h2>
+      <button cx-on:click=${() => setColor(color() === 'red' ? 'blue' : 'red')}>
+        Toggle Color
+      </button>
+      <span cx:style:color=${() => color()}>This text changes color</span>
+    </section>
+
+    <section>
+      <h2>For Directive (cx:for)</h2>
+      <ul>
+        <li cx:for=${() => items()}>Static item</li>
+      </ul>
     </section>
   `;
 });


### PR DESCRIPTION
## Summary
- implement `cx:for`, `cx:show`, `cx:model` and `cx:style` directives
- exclude new directive names from `reactiveAttr` matching
- register all directives
- document them in the README
- test each new directive
- showcase new directives in the playground

## Testing
- `pnpm exec vitest run` *(fails: `pnpm` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6842eb459b14832fb995656980899e39