### PR TITLE
Fix lint issues and test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A modern frontend framework with signal-based state, shadow DOM, and custom directives",
   "scripts": {
     "dev": "vite --config playground/vite.config.ts",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "build": "rollup -c",
@@ -22,7 +22,6 @@
   "author": "synth-rabbit <josh.dean.edwards@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "ramda": "^0.30.0"
   },
   "packageManager": "pnpm@8.14.2+sha1.1670a65b60df5f95e9f0cb7de46e605d9bd74fda",
   "devDependencies": {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -1,5 +1,4 @@
 import { createSignal, Signal } from '@crux/reactivity';
-import { find, reverse } from 'ramda';
 
 export interface Context<T> {
   id: symbol;
@@ -49,11 +48,13 @@ export function provide<T>(context: Context<T>, defaultValue?: T) {
  * Retrieves the signal for a given context.
  */
 export function useContext<T>(context: Context<T>): Signal<T> | undefined {
-  const map = find<ContextMap>(
-    (m) => m.has(context.id),
-    reverse(contextStack)
-  );
-  return map ? (map.get(context.id) as Signal<T>) : (context.defaultValue as Signal<T>);
+  for (let i = contextStack.length - 1; i >= 0; i--) {
+    const map = contextStack[i];
+    if (map.has(context.id)) {
+      return map.get(context.id) as Signal<T>;
+    }
+  }
+  return context.defaultValue as Signal<T>;
 }
 
 /** Internal helper to reset the context stack for tests. */

--- a/packages/core/src/createCruxApp.ts
+++ b/packages/core/src/createCruxApp.ts
@@ -5,11 +5,9 @@ interface CreateCruxAppOptions {
   selector: string;
 }
 
-import { isNil } from 'ramda';
-
 export function createCruxApp({ root, selector }: CreateCruxAppOptions) {
   const mountPoint = document.querySelector(selector);
-  if (isNil(mountPoint)) {
+  if (!mountPoint) {
     console.error(`[crux] Mount point '${selector}' not found.`);
     return;
   }

--- a/packages/core/src/directives/for.ts
+++ b/packages/core/src/directives/for.ts
@@ -14,12 +14,16 @@ export const forDirective: Directive = {
     const template = el.cloneNode(true) as Element;
     parent.replaceChild(placeholder, el);
 
-    let nodes: Node[] = [];
+    const nodes: Node[] = [];
     const render = (list: unknown[]) => {
-      nodes.forEach((n) => n.remove());
-      nodes = [];
-      if (!Array.isArray(list)) return;
-      for (let i = 0; i < list.length; i++) {
+      if (!Array.isArray(list)) list = [];
+
+      while (nodes.length > list.length) {
+        const node = nodes.pop()!;
+        node.remove();
+      }
+
+      while (nodes.length < list.length) {
         const clone = template.cloneNode(true);
         parent.insertBefore(clone, placeholder);
         nodes.push(clone);

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,5 +1,4 @@
 import { effect } from '@crux/reactivity';
-import { map } from 'ramda';
 
 export const cxText = <T>(sig: () => T) => {
   const node = document.createTextNode(String(sig()));
@@ -12,7 +11,7 @@ export const cxText = <T>(sig: () => T) => {
 export const cxList =
   <T>(getList: () => T[], mapFn: (item: T) => Node) =>
   () =>
-    map(mapFn, getList());
+    getList().map(mapFn);
 
 export const cxClass =
   (condition: () => boolean, trueClass: string, falseClass = '') =>

--- a/packages/reactivity/src/scheduler.ts
+++ b/packages/reactivity/src/scheduler.ts
@@ -1,8 +1,8 @@
 // scheduler.ts
 import type { ReactiveEffect } from './types';
-import { includes, forEach } from 'ramda';
 
 const queue: ReactiveEffect[] = [];
+const pending = new Set<ReactiveEffect>();
 let flushing = false;
 
 /**
@@ -10,7 +10,8 @@ let flushing = false;
  * Ensures effects added during a flush cycle are deferred to the next microtask.
  */
 export function queueJob(job: ReactiveEffect): void {
-  if (!includes(job, queue)) {
+  if (!pending.has(job)) {
+    pending.add(job);
     queue.push(job);
     if (!flushing) {
       queueMicrotask(flush);
@@ -22,18 +23,10 @@ export function flush(): void {
   if (flushing) return;
   flushing = true;
 
-  const seen = new Set<ReactiveEffect>();
-
   while (queue.length > 0) {
-    const pending = queue.slice();
-    queue.length = 0;
-
-    forEach((job: ReactiveEffect) => {
-      if (!seen.has(job)) {
-        seen.add(job);
-        job();
-      }
-    }, pending);
+    const job = queue.shift()!;
+    job();
+    pending.delete(job);
   }
 
   flushing = false;

--- a/packages/reactivity/src/signal.ts
+++ b/packages/reactivity/src/signal.ts
@@ -1,7 +1,6 @@
 import { queueJob } from './scheduler';
 import { currentEffect } from './effect';
 import type { ReactiveEffect, Signal } from './types';
-import { forEach } from 'ramda';
 
 export function createSignal<T>(initialValue: T): Signal<T> {
   let value = initialValue;
@@ -19,7 +18,9 @@ export function createSignal<T>(initialValue: T): Signal<T> {
 
     value = newValue;
 
-    forEach(queueJob, Array.from(subscribers));
+    for (const job of subscribers) {
+      queueJob(job);
+    }
   }
 
   return [read, write];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,7 @@ settings:
 importers:
 
   .:
-    dependencies:
-      ramda:
-        specifier: ^0.30.0
-        version: 0.30.1
+    dependencies: {}
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^28.0.3
@@ -2661,9 +2658,6 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /ramda@0.30.1:
-    resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
-    dev: false
 
   /reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}


### PR DESCRIPTION
## Summary
- address prettier errors in context and html modules
- run Vitest in non-watch mode for `pnpm test`
- implement performance improvements:
  - more efficient `cx:for` diffing
  - iterative context lookup
  - lean scheduler queue
  - remove Ramda utilities from hot paths
- drop Ramda dependency

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6842f842bb08832fa0e471c407fe77bf