### PR TITLE
Enable props for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Crux
 
-Crux is a small experimental frontend framework.  It is organised as a `pnpm` workspace containing a few packages that provide reactive primitives, context support and DOM helpers.  A Vite based playground under `./playground` demonstrates how everything fits together.
+Crux is a small experimental frontend framework. It is organised as a `pnpm` workspace containing a few packages that provide reactive primitives, context support and DOM helpers. A Vite based playground under `./playground` demonstrates how everything fits together.
 
 ## Packages
 
-- **`@crux/reactivity`** – signal based reactivity with `createSignal`, `effect`, and `computed`.  A tiny scheduler ensures effects run asynchronously.
+- **`@crux/reactivity`** – signal based reactivity with `createSignal`, `effect`, and `computed`. A tiny scheduler ensures effects run asynchronously.
 - **`@crux/context`** – context utilities (`createContext`, `provide`, `useContext`) built on top of signals.
-- **`@crux/core`** – helpers for creating custom elements and rendering HTML templates.  Includes the `html` template tag and directives such as `cx-on`, `cx:if`, `cx:show`, `cx:model`, `cx:style`, and `cx:for`.
+- **`@crux/core`** – helpers for creating custom elements and rendering HTML templates. Includes the `html` template tag and directives such as `cx-on`, `cx:if`, `cx:show`, `cx:model`, `cx:style`, and `cx:for`.
 
 ## Getting started
 
@@ -33,15 +33,23 @@ Creating a simple component:
 import { defineComponent, html } from '@crux/core';
 import { createSignal } from '@crux/reactivity';
 
-defineComponent('hello-world', () => {
+defineComponent('hello-world', (props) => {
   const [count, setCount] = createSignal(0);
   return html`
     <button cx-on:click=${() => setCount(count() + 1)}>
-      Clicked ${count} times
+      ${props.label ?? 'Clicked'} ${count} times
     </button>
   `;
 });
 ```
+
+Props can be passed as attributes when using the component:
+
+```html
+<hello-world label="Press"></hello-world>
+```
+
+You can see this in action by running the playground (`pnpm dev`).
 
 Mount the root component using `createCruxApp` in `main.ts`:
 

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -1,15 +1,24 @@
 import { withContextScope } from '@crux/context';
 
-export function defineComponent(tag: string, setup: () => DocumentFragment) {
+export function defineComponent<P extends Record<string, any> = Record<string, string>>(
+  tag: string,
+  setup: (props: P) => DocumentFragment
+) {
   customElements.define(
     tag,
     class extends HTMLElement {
-      shadow: ShadowRoot;
+      shadow!: ShadowRoot;
 
-      constructor() {
-        super();
+      connectedCallback() {
+        if (this.shadowRoot) return;
         this.shadow = this.attachShadow({ mode: 'open' });
-        const fragment = withContextScope(setup);
+
+        const props = {} as Record<string, string>;
+        for (const name of this.getAttributeNames()) {
+          props[name] = this.getAttribute(name)!;
+        }
+
+        const fragment = withContextScope(() => setup(props as P));
         this.shadow.appendChild(fragment);
       }
     }

--- a/packages/core/test/component.test.ts
+++ b/packages/core/test/component.test.ts
@@ -3,11 +3,11 @@ import { defineComponent } from '@crux/core';
 
 describe('defineComponent', () => {
   const tagName = 'x-test-element';
+  const propsTag = 'x-test-props';
 
   beforeEach(() => {
-    // Ensure no conflict with already defined custom elements in repeated runs
-    if (customElements.get(tagName)) {
-      // Skip if element is already defined, as there's no standard API to undefine
+    // Skip setup if elements already defined, as they cannot be redefined
+    if (customElements.get(tagName) || customElements.get(propsTag)) {
       return;
     }
   });
@@ -22,10 +22,20 @@ describe('defineComponent', () => {
     defineComponent(tagName, setup);
 
     const el = document.createElement(tagName) as HTMLElement & { shadow: ShadowRoot };
+    document.body.appendChild(el);
 
     expect(setup).toHaveBeenCalledTimes(1);
     expect(el.shadowRoot).toBeInstanceOf(ShadowRoot);
     expect(el.shadowRoot?.childNodes.length).toBe(1);
     expect(el.shadowRoot?.firstChild?.textContent).toBe('Hello');
+  });
+
+  it('passes attributes as props to setup', () => {
+    const setup = vi.fn(() => document.createDocumentFragment());
+    defineComponent(propsTag, setup);
+
+    document.body.innerHTML = `<${propsTag} foo="bar" answer="42"></${propsTag}>`;
+
+    expect(setup).toHaveBeenCalledWith(expect.objectContaining({ foo: 'bar', answer: '42' }));
   });
 });

--- a/playground/components/App.ts
+++ b/playground/components/App.ts
@@ -9,6 +9,7 @@ import { provide, useContext } from '@crux/context';
 import { computed, createSignal } from '@crux/reactivity';
 import { ThemeContext } from '../context/ThemeContext';
 import './ContextChild';
+import './HelloWorld';
 
 // Root component showcasing the main Crux features
 defineComponent('my-app', () => {
@@ -55,6 +56,11 @@ defineComponent('my-app', () => {
     <section>
       <h2>Computed Signal</h2>
       <p>Double: ${cxText(() => doubleCount())}</p>
+    </section>
+
+    <section>
+      <h2>Props Example</h2>
+      <hello-world label="Press"></hello-world>
     </section>
 
     <section>

--- a/playground/components/HelloWorld.ts
+++ b/playground/components/HelloWorld.ts
@@ -1,0 +1,16 @@
+import { defineComponent, html } from '@crux/core';
+import { createSignal } from '@crux/reactivity';
+
+// Example component demonstrating props usage
+export interface HelloWorldProps {
+  label?: string;
+}
+
+defineComponent('hello-world', (props: HelloWorldProps) => {
+  const [count, setCount] = createSignal(0);
+  return html`
+    <button cx-on:click=${() => setCount(count() + 1)}>
+      ${props.label ?? 'Clicked'} ${count} times
+    </button>
+  `;
+});


### PR DESCRIPTION
## Summary
- allow `defineComponent` to accept props
- document how to use props in components
- test passing attributes as props
- mention props example in playground
- showcase props in the playground app

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68431cc52ae0832faac01e896664832b