### PR TITLE
Improve router with nested and dynamic route support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Crux is a small experimental frontend framework. It is organised as a `pnpm` wor
 - **`@crux/reactivity`** – signal based reactivity with `createSignal`, `effect`, and `computed`. A tiny scheduler ensures effects run asynchronously.
 - **`@crux/context`** – context utilities (`createContext`, `provide`, `useContext`) built on top of signals.
 - **`@crux/core`** – helpers for creating custom elements and rendering HTML templates. Includes the `html` template tag and directives such as `cx-on`, `cx:if`, `cx:show`, `cx:model`, `cx:style`, and `cx:for`.
+- **`@crux/router`** – client side router supporting nested routes, dynamic segments, query strings and a handy `<cx-link>` component.
 
 ## Getting started
 
@@ -56,10 +57,28 @@ Mount the root component using `createCruxApp` in `main.ts`:
 ```ts
 import './hello-world.ts';
 import { createCruxApp } from '@crux/core';
-
 createCruxApp({
   root: 'hello-world',
   selector: '#app',
+  router: {
+    root: {
+      path: '/',
+      component: 'hello-world',
+      children: [{ path: 'todos/:id', component: 'todo-detail' }],
+    },
+  },
+});
+```
+
+Inside components you can access route details via `useRoute`:
+
+```ts
+import { defineComponent, html } from '@crux/core';
+import { useRoute } from '@crux/router';
+
+defineComponent('todo-detail', () => {
+  const { params, query } = useRoute();
+  return html`<p>Todo ${params.id} sorted by ${query.sort}</p>`;
 });
 ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,5 +2,8 @@
   "name": "@crux/core",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts"
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@crux/router": "0.1.0"
+  }
 }

--- a/packages/core/src/createCruxApp.ts
+++ b/packages/core/src/createCruxApp.ts
@@ -1,11 +1,19 @@
+import { provideRouter, createRouter, Route, RouterConfig } from '@crux/router';
+import { withContextScope } from '@crux/context';
+
 interface CreateCruxAppOptions {
   /** Custom element tag name, e.g., 'my-app' */
   root: string;
   /** CSS selector to mount on */
   selector: string;
+  /** Optional router setup */
+  router?: {
+    config?: RouterConfig;
+    root: Route;
+  };
 }
 
-export function createCruxApp({ root, selector }: CreateCruxAppOptions) {
+export function createCruxApp({ root, selector, router }: CreateCruxAppOptions) {
   const mountPoint = document.querySelector(selector);
   if (!mountPoint) {
     console.error(`[crux] Mount point '${selector}' not found.`);
@@ -13,5 +21,13 @@ export function createCruxApp({ root, selector }: CreateCruxAppOptions) {
   }
 
   const el = document.createElement(root);
-  mountPoint.appendChild(el);
+  if (router) {
+    const r = createRouter(router.root, router.config);
+    withContextScope(() => {
+      provideRouter(r);
+      mountPoint.appendChild(el);
+    });
+  } else {
+    mountPoint.appendChild(el);
+  }
 }

--- a/packages/core/test/createCruxApp.test.ts
+++ b/packages/core/test/createCruxApp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, vi } from 'vitest';
-import { createCruxApp } from '@crux/core';
+import { createCruxApp, defineComponent, html } from '@crux/core';
+import { useRouter } from '@crux/router';
 
 describe('createCruxApp', () => {
   test('mounts root component into target', () => {
@@ -13,5 +14,22 @@ describe('createCruxApp', () => {
     createCruxApp({ root: 'my-app', selector: '#nonexistent' });
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  test('provides router when configured', () => {
+    defineComponent('router-root', () => {
+      const r = useRouter();
+      return html`<span>${r.currentPath[0]()}</span>`;
+    });
+
+    document.body.innerHTML = `<div id="app"></div>`;
+    createCruxApp({
+      root: 'router-root',
+      selector: '#app',
+      router: { root: { path: '/', component: 'router-root' } },
+    });
+
+    const span = document.querySelector('router-root')!.shadowRoot!.querySelector('span');
+    expect(span?.textContent).toBe('/');
   });
 });

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@crux/router",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
+}

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,0 +1,4 @@
+export type { Route, Router, RouterConfig, RouteMatch } from './router';
+export { createRouter, RouterContext, provideRouter, useRouter, useRoute } from './router';
+export type { CxLinkProps } from './link';
+import './link';

--- a/packages/router/src/link.ts
+++ b/packages/router/src/link.ts
@@ -1,0 +1,25 @@
+import { useRouter } from './router';
+
+export interface CxLinkProps {
+  to: string;
+  label?: string;
+}
+
+class CxLink extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const router = useRouter();
+    const root = this.attachShadow({ mode: 'open' });
+    const anchor = document.createElement('a');
+    const to = this.getAttribute('to') || '/';
+    anchor.setAttribute('href', to);
+    anchor.textContent = this.getAttribute('label') || '';
+    anchor.addEventListener('click', (e) => {
+      e.preventDefault();
+      router.push(to);
+    });
+    root.appendChild(anchor);
+  }
+}
+
+customElements.define('cx-link', CxLink);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,0 +1,123 @@
+import { createSignal } from '@crux/reactivity';
+import { createContext, provide, useContext } from '@crux/context';
+import type { Signal } from '@crux/reactivity';
+
+export interface Route {
+  path: string;
+  component: string;
+  children?: Route[];
+}
+
+export interface RouterConfig {
+  base?: string;
+}
+
+export interface RouteMatch {
+  /** full pathname without the query string */
+  path: string;
+  /** matched route record */
+  route: Route;
+  /** dynamic parameters extracted from the path */
+  params: Record<string, string>;
+  /** parsed query string values */
+  query: Record<string, string>;
+}
+
+export interface Router {
+  /** current full path including query */
+  currentPath: Signal<string>;
+  /** computed details for the current route */
+  currentRoute: Signal<RouteMatch>;
+  push(path: string): void;
+  replace(path: string): void;
+  root: Route;
+}
+
+export const RouterContext = createContext<Router>();
+
+function normalize(base: string, p: string): string {
+  if (base && p.startsWith(base)) p = p.slice(base.length);
+  return p.startsWith('/') ? p : '/' + p;
+}
+
+function parseQuery(q: string): Record<string, string> {
+  const query: Record<string, string> = {};
+  q.replace(/^\?/, '')
+    .split('&')
+    .filter(Boolean)
+    .forEach((part) => {
+      const [k, v] = part.split('=');
+      if (k) query[decodeURIComponent(k)] = decodeURIComponent(v ?? '');
+    });
+  return query;
+}
+
+function matchRoute(root: Route, fullPath: string): RouteMatch {
+  const [pathPart, search = ''] = fullPath.split('?');
+  const segments = pathPart.replace(/^\//, '').split('/').filter(Boolean);
+  const params: Record<string, string> = {};
+  let current = root;
+
+  let children = root.children ?? [];
+  for (const seg of segments) {
+    let matched: Route | undefined;
+    for (const r of children) {
+      if (r.path === seg) {
+        matched = r;
+        break;
+      }
+      if (r.path.startsWith(':')) {
+        params[r.path.slice(1)] = seg;
+        matched = r;
+        break;
+      }
+    }
+    if (!matched) break;
+    current = matched;
+    children = matched.children ?? [];
+  }
+
+  return { path: '/' + segments.join('/'), route: current, params, query: parseQuery(search) };
+}
+
+export function createRouter(root: Route, config: RouterConfig = {}): Router {
+  const base = config.base ?? '';
+  const currentUrl = normalize(base, window.location.pathname + window.location.search);
+  const [path, setPath] = createSignal(currentUrl);
+  const [current, setCurrent] = createSignal(matchRoute(root, currentUrl));
+
+  const update = (to: string, method: 'push' | 'replace') => {
+    const full = base + to;
+    history[method + 'State'](null, '', full);
+    const normalized = normalize(base, to);
+    setPath(normalized);
+    setCurrent(matchRoute(root, normalized));
+  };
+
+  const push = (to: string) => update(to, 'push');
+  const replace = (to: string) => update(to, 'replace');
+
+  window.addEventListener('popstate', () => {
+    const loc = normalize(base, window.location.pathname + window.location.search);
+    setPath(loc);
+    setCurrent(matchRoute(root, loc));
+  });
+
+  return { currentPath: [path, setPath], currentRoute: [current, setCurrent], push, replace, root };
+}
+
+export function provideRouter(router: Router) {
+  provide(RouterContext, router);
+}
+
+export function useRouter(): Router {
+  const sig = useContext(RouterContext);
+  if (!sig) {
+    throw new Error('[crux/router] Router context not found');
+  }
+  return sig[0]();
+}
+
+export function useRoute(): RouteMatch {
+  return useRouter().currentRoute[0]();
+}

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { withContextScope, useContext } from '@crux/context';
+import { defineComponent, html } from '@crux/core';
+import { createRouter, provideRouter, RouterContext } from '../src/router';
+import '../src/link';
+
+describe('router', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/');
+  });
+  it('updates current path on push', () => {
+    const router = createRouter({ path: '/', component: 'x-root' });
+    expect(router.currentPath[0]()).toBe('/');
+    router.push('/test');
+    expect(router.currentPath[0]()).toBe('/test');
+    router.replace('/');
+  });
+
+  it('provides router via context', () => {
+    const router = createRouter({ path: '/', component: 'x-root' });
+
+    let path = '';
+    defineComponent('x-test', () => {
+      const sig = useContext(RouterContext)!;
+      path = sig[0]().currentPath[0]();
+      return html``;
+    });
+
+    withContextScope(() => {
+      provideRouter(router);
+      const el = document.createElement('x-test');
+      document.body.appendChild(el);
+    });
+
+    expect(path).toBe('/');
+  });
+
+  it('cx-link navigates using router', () => {
+    const router = createRouter({ path: '/', component: 'x-root' });
+
+    withContextScope(() => {
+      provideRouter(router);
+      const el = document.createElement('cx-link');
+      el.setAttribute('to', '/foo');
+      el.setAttribute('label', 'Go');
+      document.body.appendChild(el);
+      const anchor = el.shadowRoot!.querySelector('a')!;
+      anchor.dispatchEvent(new Event('click'));
+    });
+
+    expect(router.currentPath[0]()).toBe('/foo');
+  });
+
+  it('parses query strings', () => {
+    const router = createRouter({ path: '/', component: 'x-root' });
+    router.push('/todos?sort=asc');
+    expect(router.currentRoute[0]().query.sort).toBe('asc');
+  });
+
+  it('matches dynamic and nested routes', () => {
+    const router = createRouter({
+      path: '/',
+      component: 'x-root',
+      children: [
+        {
+          path: 'todos',
+          component: 'x-todos',
+          children: [{ path: ':id', component: 'x-detail' }],
+        },
+      ],
+    });
+
+    router.push('/todos/1');
+    const match = router.currentRoute[0]();
+    expect(match.route.component).toBe('x-detail');
+    expect(match.params.id).toBe('1');
+  });
+});

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "paths": {
       "@crux/reactivity": ["./packages/reactivity/src"],
       "@crux/core": ["./packages/core/src"],
-      "@crux/context": ["./packages/context/src"]
+      "@crux/context": ["./packages/context/src"],
+      "@crux/router": ["./packages/router/src"]
     }
   },
   "include": ["packages/*/src", "packages/*/test"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       '@crux/context': path.resolve(__dirname, 'packages/context/src'),
       '@crux/reactivity': path.resolve(__dirname, 'packages/reactivity/src'),
       '@crux/core': path.resolve(__dirname, 'packages/core/src'),
+      '@crux/router': path.resolve(__dirname, 'packages/router/src'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- enhance `@crux/router` to parse query strings and match nested routes with dynamic segments
- expose `currentRoute` info via `useRoute`
- demonstrate advanced routing in README
- extend router tests for new functionality

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684354e07a14832fae5c4d680acd12b4