### PR TITLE
Add form demo to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Crux is a small experimental frontend framework. It is organised as a `pnpm` wor
 - **`@crux/context`** – context utilities (`createContext`, `provide`, `useContext`) built on top of signals.
 - **`@crux/core`** – helpers for creating custom elements and rendering HTML templates. Includes the `html` template tag and directives such as `cx-on`, `cx:if`, `cx:show`, `cx:model`, `cx:style`, and `cx:for`.
 - **`@crux/router`** – client side router supporting nested routes, dynamic segments, query strings and a handy `<cx-link>` component.
+- **`@crux/forms`** – utilities for managing form state and validations.
 
 ## Getting started
 

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@crux/forms",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
+}

--- a/packages/forms/src/form.ts
+++ b/packages/forms/src/form.ts
@@ -1,0 +1,48 @@
+import { createSignal } from '@crux/reactivity';
+import type { Signal } from '@crux/reactivity';
+
+export type Validator<T> = (value: T) => string | null | undefined;
+export type Validators<T> = { [K in keyof T]?: Validator<T[K]> };
+
+export interface Field<T> {
+  value: Signal<T>;
+  error: Signal<string | null>;
+}
+
+export interface Form<T> {
+  fields: { [K in keyof T]: Field<T[K]> };
+  validate(): boolean;
+  values(): T;
+}
+
+export function createForm<T extends Record<string, any>>(initial: T, validators: Validators<T> = {}): Form<T> {
+  const fields = {} as { [K in keyof T]: Field<T[K]> };
+
+  for (const key of Object.keys(initial) as (keyof T)[]) {
+    const [val, setVal] = createSignal(initial[key]);
+    const [err, setErr] = createSignal<string | null>(null);
+    fields[key] = { value: [val, setVal], error: [err, setErr] } as Field<T[keyof T]>;
+  }
+
+  const validate = (): boolean => {
+    let ok = true;
+    for (const key of Object.keys(fields) as (keyof T)[]) {
+      const validator = validators[key];
+      const v = fields[key].value[0]();
+      const msg = validator ? validator(v) : null;
+      fields[key].error[1](msg ?? null);
+      if (msg) ok = false;
+    }
+    return ok;
+  };
+
+  const values = (): T => {
+    const result = {} as T;
+    for (const key of Object.keys(fields) as (keyof T)[]) {
+      result[key] = fields[key].value[0]();
+    }
+    return result;
+  };
+
+  return { fields, validate, values };
+}

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -1,0 +1,2 @@
+export { createForm } from './form';
+export type { Form, Field, Validator, Validators } from './form';

--- a/packages/forms/test/form.test.ts
+++ b/packages/forms/test/form.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { createForm } from '../src/form';
+
+describe('createForm', () => {
+  it('tracks field values', () => {
+    const form = createForm({ name: 'a' });
+    form.fields.name.value[1]('b');
+    expect(form.fields.name.value[0]()).toBe('b');
+  });
+
+  it('validates fields', () => {
+    const form = createForm(
+      { name: '' },
+      { name: (v) => (v ? null : 'required') }
+    );
+
+    expect(form.validate()).toBe(false);
+    expect(form.fields.name.error[0]()).toBe('required');
+
+    form.fields.name.value[1]('John');
+    expect(form.validate()).toBe(true);
+    expect(form.fields.name.error[0]()).toBe(null);
+  });
+});

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/playground/components/App.ts
+++ b/playground/components/App.ts
@@ -10,6 +10,7 @@ import { computed, createSignal } from '@crux/reactivity';
 import { ThemeContext } from '../context/ThemeContext';
 import './ContextChild';
 import './HelloWorld';
+import './FormDemo';
 
 // Root component showcasing the main Crux features
 defineComponent('my-app', () => {
@@ -120,6 +121,11 @@ defineComponent('my-app', () => {
       <ul>
         <li cx:for=${() => items()}>Static item</li>
       </ul>
+    </section>
+
+    <section>
+      <h2>Form Example</h2>
+      <demo-form></demo-form>
     </section>
   `;
 });

--- a/playground/components/FormDemo.ts
+++ b/playground/components/FormDemo.ts
@@ -1,0 +1,59 @@
+import { defineComponent, html, cxText } from '@crux/core';
+import { createForm } from '@crux/forms';
+
+export interface DemoData {
+  name: string;
+  email: string;
+  message: string;
+}
+
+defineComponent('demo-form', () => {
+  const form = createForm<DemoData>(
+    { name: '', email: '', message: '' },
+    {
+      name: (v) => (v ? null : 'Name is required'),
+      email: (v) => (/^\S+@\S+\.\S+$/.test(v) ? null : 'Invalid email'),
+      message: (v) => (v ? null : 'Message required'),
+    }
+  );
+
+  const submit = (e: Event) => {
+    e.preventDefault();
+    if (form.validate()) {
+      alert(JSON.stringify(form.values()));
+    }
+  };
+
+  return html`
+    <form cx-on:submit=${submit} novalidate>
+      <div>
+        <label>
+          Name
+          <input cx:model=${form.fields.name.value} />
+        </label>
+        <p cx:show=${() => !!form.fields.name.error[0]()} style="color: red">
+          ${cxText(() => form.fields.name.error[0]())}
+        </p>
+      </div>
+      <div>
+        <label>
+          Email
+          <input type="email" cx:model=${form.fields.email.value} />
+        </label>
+        <p cx:show=${() => !!form.fields.email.error[0]()} style="color: red">
+          ${cxText(() => form.fields.email.error[0]())}
+        </p>
+      </div>
+      <div>
+        <label>
+          Message
+          <textarea cx:model=${form.fields.message.value}></textarea>
+        </label>
+        <p cx:show=${() => !!form.fields.message.error[0]()} style="color: red">
+          ${cxText(() => form.fields.message.error[0]())}
+        </p>
+      </div>
+      <button type="submit">Submit</button>
+    </form>
+  `;
+});

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -4,7 +4,8 @@
     "paths": {
       "@crux/core": ["../packages/core/src"],
       "@crux/reactivity": ["../packages/reactivity/src"],
-      "@crux/context": ["../packages/context/src"]
+      "@crux/context": ["../packages/context/src"],
+      "@crux/forms": ["../packages/forms/src"]
     }
   }
 }

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -19,7 +19,8 @@ export default defineConfig({
     alias: {
       "@crux/reactivity": path.resolve(__dirname, "../packages/reactivity/src"),
       "@crux/core": path.resolve(__dirname, "../packages/core/src"),
-      "@crux/context": path.resolve(__dirname, "../packages/context/src")
+      "@crux/context": path.resolve(__dirname, "../packages/context/src"),
+      "@crux/forms": path.resolve(__dirname, "../packages/forms/src")
     }
   }
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
       "@crux/reactivity": ["./packages/reactivity/src"],
       "@crux/core": ["./packages/core/src"],
       "@crux/context": ["./packages/context/src"],
-      "@crux/router": ["./packages/router/src"]
+      "@crux/router": ["./packages/router/src"],
+      "@crux/forms": ["./packages/forms/src"]
     }
   },
   "include": ["packages/*/src", "packages/*/test"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       '@crux/reactivity': path.resolve(__dirname, 'packages/reactivity/src'),
       '@crux/core': path.resolve(__dirname, 'packages/core/src'),
       '@crux/router': path.resolve(__dirname, 'packages/router/src'),
+      '@crux/forms': path.resolve(__dirname, 'packages/forms/src'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- include alias for `@crux/forms` in playground configuration
- add a `demo-form` component showing form helpers
- render the form demo in the playground app

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68435e1ddff8832fb363cee1175ff19a