### PR TITLE
Add store support to reactivity package

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -1,4 +1,6 @@
 export { createSignal } from './signal';
 export { effect, onCleanup } from './effect';
 export { computed } from './computed';
+export { createStore } from './store';
+export type { Store } from './store';
 export type { Accessor, Setter, ReactiveEffect, Signal } from './types';

--- a/packages/reactivity/src/store.ts
+++ b/packages/reactivity/src/store.ts
@@ -1,0 +1,34 @@
+import { createSignal } from './signal';
+import type { Signal } from './types';
+
+export interface Store<T> {
+  state: { [K in keyof T]: Signal<T[K]> };
+  setState(patch: Partial<T>): void;
+  getState(): T;
+}
+
+export function createStore<T extends Record<string, any>>(initial: T): Store<T> {
+  const state = {} as { [K in keyof T]: Signal<T[K]> };
+
+  for (const key of Object.keys(initial) as (keyof T)[]) {
+    state[key] = createSignal(initial[key]);
+  }
+
+  const setState = (patch: Partial<T>): void => {
+    for (const key of Object.keys(patch) as (keyof T)[]) {
+      if (key in state) {
+        state[key][1](patch[key] as T[keyof T]);
+      }
+    }
+  };
+
+  const getState = (): T => {
+    const result = {} as T;
+    for (const key of Object.keys(state) as (keyof T)[]) {
+      result[key] = state[key][0]();
+    }
+    return result;
+  };
+
+  return { state, setState, getState };
+}

--- a/packages/reactivity/test/store.test.ts
+++ b/packages/reactivity/test/store.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { createStore } from '../src/store';
+
+describe('createStore', () => {
+  it('initializes signals for each property', () => {
+    const store = createStore({ count: 0, text: 'a' });
+    store.state.count[1](1);
+    store.state.text[1]('b');
+    expect(store.state.count[0]()).toBe(1);
+    expect(store.state.text[0]()).toBe('b');
+  });
+
+  it('setState updates multiple properties', () => {
+    const store = createStore({ a: 1, b: 2 });
+    store.setState({ a: 3, b: 4 });
+    expect(store.getState()).toEqual({ a: 3, b: 4 });
+  });
+
+  it('getState returns current values', () => {
+    const store = createStore({ a: 0, b: '' });
+    store.state.a[1](1);
+    expect(store.getState()).toEqual({ a: 1, b: '' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `createStore` for grouped state management
- re-export new store utilities from reactivity index
- test store behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684361fa1634832f94dde3837db12e83